### PR TITLE
Fixes Varios

### DIFF
--- a/Data/Scripts/011_Battle/012_PokeBattle_Battle.rb
+++ b/Data/Scripts/011_Battle/012_PokeBattle_Battle.rb
@@ -2180,20 +2180,12 @@ class PokeBattle_Battle
     return if !@battlers[index] || !@battlers[index].pokemon
     return if !(@battlers[index].hasPrimal? rescue false)
     return if (@battlers[index].isPrimal? rescue true)
-    if isConst?(@battlers[index].pokemon.species,PBSpecies,:KYOGRE)
-      pbCommonAnimation("PrimalKyogre",@battlers[index],nil)
-    elsif isConst?(@battlers[index].pokemon.species,PBSpecies,:GROUDON)
-      pbCommonAnimation("PrimalGroudon",@battlers[index],nil)
-    end
+    pbCommonAnimation("Primal#{PBSpecies.getName(@battlers[index].species)}",@battlers[index],nil)
     @battlers[index].pokemon.makePrimal
     @battlers[index].form=@battlers[index].pokemon.form
     @battlers[index].pbUpdate(true)
     @scene.pbChangePokemon(@battlers[index],@battlers[index].pokemon)
-    if isConst?(@battlers[index].pokemon.species,PBSpecies,:KYOGRE)
-      pbCommonAnimation("PrimalKyogre2",@battlers[index],nil)
-    elsif isConst?(@battlers[index].pokemon.species,PBSpecies,:GROUDON)
-      pbCommonAnimation("PrimalGroudon2",@battlers[index],nil)
-    end
+    pbCommonAnimation("Primal#{PBSpecies.getName(@battlers[index].species)}2",@battlers[index],nil)
     pbDisplay(_INTL("¡{1} ha esperimentado una Regresión Primigenia y ha recobrado su apariencia primitiva!",@battlers[index].pbThis))
     PBDebug.log("[Regresión Primigenia] #{@battlers[index].pbThis} ha recobrado su apariencia primitiva")
   end

--- a/Data/Scripts/011_Battle/015_PokeBattle_Scene.rb
+++ b/Data/Scripts/011_Battle/015_PokeBattle_Scene.rb
@@ -739,12 +739,10 @@ class PokemonDataBox < SpriteWrapper
     end
     if @battler.isMega?
       imagepos.push(["Graphics/#{BATTLE_ROUTE}/battleMegaEvoBox.png",@spritebaseX+8,34,0,0,-1,-1])
+    elsif @battler.isUltra?
+      imagepos.push(["Graphics/#{BATTLE_ROUTE}/battleUltraBurstBox.png",@spritebaseX+140,4,0,0,-1,-1])
     elsif @battler.isPrimal?
-      if isConst?(@battler.pokemon.species,PBSpecies,:KYOGRE)
-        imagepos.push(["Graphics/#{BATTLE_ROUTE}/battlePrimalKyogreBox.png",@spritebaseX+140,4,0,0,-1,-1])
-      elsif isConst?(@battler.pokemon.species,PBSpecies,:GROUDON)
-        imagepos.push(["Graphics/#{BATTLE_ROUTE}/battlePrimalGroudonBox.png",@spritebaseX+140,4,0,0,-1,-1])
-      end
+      imagepos.push(["Graphics/#{BATTLE_ROUTE}/battlePrimal#{PBSpecies.getName(@battler.species)}Box.png",@spritebaseX+140,4,0,0,-1,-1])
     elsif @battler.isTera?
       imagepos.push(["Graphics/Pictures/teraTypes.png",@spritebaseX+140,4,0,@battler.type1*32,32,32])
     end

--- a/Data/Scripts/015_Pokemon/002_Pokemon_MultipleForms.rb
+++ b/Data/Scripts/015_Pokemon/002_Pokemon_MultipleForms.rb
@@ -1443,7 +1443,7 @@ MultipleForms.register(:NECROZMA,{
   end
 },
 "getUltraForm"=>proc{|pokemon|
-   next 3 if isConst?(pokemon.item,PBItems,:ULTRANECROZIUMZ) && (pokemon.form==1 || pokemon.form==2)
+   next 3 if isConst?(pokemon.item,PBItems,:ULTRANECROZIUMZ) && pokemon.form > 0
    next
 },
 "getUltraName"=>proc{|pokemon|


### PR DESCRIPTION
Modifica la forma en la que se cargan los íconos de los pokémon primigenios, para que no se tengan que modificar ciertas interfaces al añadir nuevas regresiones primigenias. Corrige un proble que hace que isUltra? siempre devuelva false y ahora muestra el ícono de la Ultraexplosión.
![battleUltraBurstBox](https://github.com/PokeLiberty/Essentials-BES/assets/120237747/72ddf533-9b56-4288-be5e-c8257945e06b)
