### PR TITLE
Disfraz bugfix

### DIFF
--- a/Data/Scripts/008_Objects and windows/001_BitmapCache.rb
+++ b/Data/Scripts/008_Objects and windows/001_BitmapCache.rb
@@ -371,6 +371,7 @@ module BitmapCache
     cached=true
     path=canonicalize(path)
     objPath=fromCache(path)
+    
     if !objPath
       @cleancounter = ((@cleancounter || 0) + 1)%10
       if @cleancounter == 0
@@ -381,18 +382,24 @@ module BitmapCache
           end
         end
       end
-      begin
-        bm = BitmapWrapper.new(path)
-      rescue Hangup
+
+      # Avoid trying to load bitmaps that don't exist
+      if path[/\/$/]
+        bm = BitmapWrapper.new(32,32)
+      else
         begin
           bm = BitmapWrapper.new(path)
+        rescue Hangup
+          begin
+            bm = BitmapWrapper.new(path)
+          rescue
+            raise _INTL("Failed to load the bitmap located at: {1}",path) if !failsafe
+            bm = BitmapWrapper.new(32,32)
+          end
         rescue
           raise _INTL("Failed to load the bitmap located at: {1}",path) if !failsafe
           bm = BitmapWrapper.new(32,32)
         end
-      rescue
-        raise _INTL("Failed to load the bitmap located at: {1}",path) if !failsafe
-        bm = BitmapWrapper.new(32,32)
       end
       objPath=bm
       @cache[path]=objPath

--- a/Data/Scripts/011_Battle/007_PokeBattle_Battler.rb
+++ b/Data/Scripts/011_Battle/007_PokeBattle_Battler.rb
@@ -4025,7 +4025,7 @@ class PokeBattle_Battler
       # Disguise
       if target.hasWorkingAbility(:DISGUISE) &&
         isConst?(target.species,PBSpecies,:MIMIKYU) && target.form==0 &&
-        thismove.pbIsDamaging? && !target.damagestate.substitute &&
+        thismove.pbIsDamaging? && !(user.effects[PBEffects::TwoTurnAttack] > 0) && !target.damagestate.substitute && thismove
         !user.hasMoldBreaker && !thismove.doesBypassIgnorableAbilities?
         PBDebug.log("[Ability triggered] #{target.pbThis}'s Disguise ended")
         @battle.pbDisplay(_INTL("¡El disfraz ha actuado como señuelo!"))


### PR DESCRIPTION
* Disfraz se rompía en turno 1 al usar un movimiento de dos turnos
* Evita intentar crear bitmaps que acaben con `/` (es decir, directorios) (esto ocurre, por ejemplo, cuando un mapa tiene al menos un slot de autotiles vacío), con tal de evitar errores innecesarios.
* * Windows no permite creación de archivos con `/` en su nombre, por lo que esto no debería suponer ningún problema