### PR TITLE
Issue #13: Protosíntesis y Carga Quark

### DIFF
--- a/Data/Scripts/011_Battle/002_PBEffects.rb
+++ b/Data/Scripts/011_Battle/002_PBEffects.rb
@@ -141,7 +141,12 @@ begin
     Commander          = 146
     GlaiveRush         = 147
     ShedTail           = 148
+    # Issue #13: Protosintesis y Carga Cuark no funcionan exactamente igual que en los juegos oficiales. - albertomcastro4
+    # El efecto de Protosíntesis también controla Carga Cuark. 
+    Protosynthesis     = 150
+    BoosterEnergy      = 151 
     
+
     ZHeal              = 149
     
     ############################################################################

--- a/Data/Scripts/011_Battle/007_PokeBattle_Battler.rb
+++ b/Data/Scripts/011_Battle/007_PokeBattle_Battler.rb
@@ -1392,6 +1392,12 @@ class PokeBattle_Battler
     end
     
     # Issue #13: Protosintesis y Carga Cuark no funcionan exactamente igual que en los juegos oficiales. - albertomcastro4
+    # Resetea el efecto cuando se pase el clima/campo
+    if (!@effects[PBEffects::BoosterEnergy] && @effects[PBEffects::Protosynthesis] > 0) && ((self.hasWorkingAbility(:PROTOSYNTHESIS) && (@battle.weather != PBWeather::SUNNYDAY)) ||            # Paleosítensis
+        (self.hasWorkingAbility(:QUARKDRIVE) && (@battle.field.effects[PBEffects::ElectricTerrain]<=0)))                                                                                    # Quark Drive    
+      @effects[PBEffects::Protosynthesis] = 0
+    end
+
     # Activación de Protosíntesis y Carga Cuark.
     if @effects[PBEffects::Protosynthesis] <= 0 && ((self.hasWorkingAbility(:PROTOSYNTHESIS) && (@battle.weather==PBWeather::SUNNYDAY || self.hasWorkingItem(:BOOSTERENERGY))) ||           # Paleosítensis
         (self.hasWorkingAbility(:QUARKDRIVE) && (@battle.field.effects[PBEffects::ElectricTerrain]>0 || self.hasWorkingItem(:BOOSTERENERGY))))  # Quark Drive      

--- a/Data/Scripts/011_Battle/009_PokeBattle_Move.rb
+++ b/Data/Scripts/011_Battle/009_PokeBattle_Move.rb
@@ -1238,6 +1238,16 @@ class PokeBattle_Move
     if attacker.hasWorkingItem(:CHOICESPECS) && pbIsSpecial?(type)
       atkmult=(atkmult*1.5).round
     end
+    
+    # Issue #13: Protosintesis y Carga Cuark no funcionan exactamente igual que en los juegos oficiales. - albertomcastro4
+    # Aumentos del ataque
+    if ((attacker.hasWorkingAbility(:PROTOSYNTHESIS) && (@battle.weather==PBWeather::SUNNYDAY || attacker.effects[PBEffects::BoosterEnergy]))             ||   # Paleosítensis
+        (attacker.hasWorkingAbility(:QUARKDRIVE) && (@battle.field.effects[PBEffects::ElectricTerrain]>0 || attacker.effects[PBEffects::BoosterEnergy]))) &&   # Quark Drive   
+        [PBStats::ATTACK, PBStats::SPATK].include?(attacker.effects[PBEffects::Protosynthesis])
+      atkmult=(atkmult*1.3).round if attacker.effects[PBEffects::Protosynthesis] == PBStats::ATTACK && pbIsPhysical?(type)
+      atkmult=(atkmult*1.5).round if attacker.effects[PBEffects::Protosynthesis] == PBStats::SPATK && pbIsSpecial?(type)
+    end
+    
     atk=(atk*atkmult*1.0/0x1000).round
     ##### Calculate opponent's defense stat #####
     defense=opponent.defense
@@ -1329,6 +1339,16 @@ class PokeBattle_Move
        !@battle.rules["souldewclause"]
       defmult=(defmult*1.5).round
     end
+    
+    # Issue #13: Protosintesis y Carga Cuark no funcionan exactamente igual que en los juegos oficiales. - albertomcastro4
+    # Aumentos de la defensa
+    if ((attacker.hasWorkingAbility(:PROTOSYNTHESIS) && (@battle.weather==PBWeather::SUNNYDAY || attacker.effects[PBEffects::BoosterEnergy]))             ||   # Paleosítensis
+        (attacker.hasWorkingAbility(:QUARKDRIVE) && (@battle.field.effects[PBEffects::ElectricTerrain]>0 || attacker.effects[PBEffects::BoosterEnergy]))) &&   # Quark Drive   
+        [PBStats::DEFENSE, PBStats::SPDEF].include?(opponent.effects[PBEffects::Protosynthesis])
+      defmult=(defmult*1.3).round if pbIsSpecial?(type) && opponent.effects[PBEffects::Protosynthesis] == PBStats::SPDEF
+      defmult=(defmult*1.3).round if pbIsPhysical?(type) && opponent.effects[PBEffects::Protosynthesis] == PBStats::DEFENSE
+    end
+
     defense=(defense*defmult*1.0/0x1000).round
     ##### Main damage calculation #####
     damage=(((2.0*attacker.level/5+2).floor*basedmg*atk/defense).floor/50).floor+2


### PR DESCRIPTION
* Reprogramadas `Protosíntesis` y `Carga Quark` con tal de recrear el comportamiento oficial, según #13.
* Añadida la función `pbWildBattlePoke`, orientada al testeo.  `pbWildBattlePoke` permite iniciar una batalla salvaje contra una instancia de `PokeBattle_Pokemon` ya creada.