### PR TITLE
Nuevo: Opción de desactivar los sprites animados.

### DIFF
--- a/Data/Scripts/019_UI/015_PScreen_Options.rb
+++ b/Data/Scripts/019_UI/015_PScreen_Options.rb
@@ -17,6 +17,7 @@ class PokemonSystem
   attr_accessor :textinput
   attr_accessor :border
   attr_accessor :font
+  attr_accessor :pkmnanim
   
   def initialize
     @textspeed     = 2     # Text speed (0=slow, 1=medium, 2=fast, 3=instant)
@@ -34,6 +35,7 @@ class PokemonSystem
     @textinput     = 0     # Text input mode (0=cursor, 1=keyboard)
     @font        = 0   # Font (see also $VersionStyles)
     @border      = 0   # Screen border (0=off, 1=on)
+    @pkmnanim      = 0     # Animación de sprites (predetermiando: encendidos)
 
   end
   
@@ -588,6 +590,16 @@ MenuHandlers.add(:options_menu, :battle_animations, {
   "description" => _INTL("Activa o desactiva las animaciones durante los combates."),
   "get_proc"    => proc { next $PokemonSystem.battlescene },
   "set_proc"    => proc { |value, _scene| $PokemonSystem.battlescene = value }
+})
+
+MenuHandlers.add(:options_menu, :pkmn_animados, {
+  "name"        => _INTL("Pokémon Animados"),
+  "order"       => 40,
+  "type"        => EnumOption,
+  "parameters"  => [_INTL("Ver"), _INTL("No ver")],
+  "description" => _INTL("Activa o desactiva los Pokémon (Sprites) Animados."),
+  "get_proc"    => proc { $PokemonSystem.pkmnanim },
+  "set_proc"    => proc { |value, _scene| $PokemonSystem.pkmnanim = value }
 })
 
 MenuHandlers.add(:options_menu, :battle_style, {

--- a/Data/Scripts/022_BES-T Scripts/007_BES-T_DesactivarPkmnAnim.rb
+++ b/Data/Scripts/022_BES-T Scripts/007_BES-T_DesactivarPkmnAnim.rb
@@ -1,0 +1,12 @@
+#===============================================================================
+# Activar/desactivar sprites animados
+# Créditos a maartiiindev_
+#===============================================================================
+class AnimatedBitmapWrapper
+  alias update_before_toggle update unless method_defined?(:update_before_toggle)
+
+  def update
+    return false if $PokemonSystem.pkmnanim == 1
+    update_before_toggle
+  end
+end


### PR DESCRIPTION
Se añadió en el menú de opciones la posibilidad de ver y no ver los Pokémon Animados.